### PR TITLE
Ability to stop ethereum node

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -399,7 +399,10 @@ func (s *Ethereum) Stop() error {
 		s.lesServer.Stop()
 	}
 	s.txPool.Stop()
-	s.miner.Stop()
+
+	if s.miner != nil {
+		s.miner.Stop()
+	}
 	s.eventMux.Stop()
 
 	s.chainDb.Close()

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -89,6 +89,8 @@ type ProtocolManager struct {
 
 	lesServer LesServer
 
+	isStarted bool
+
 	// wait group is used for graceful shutdowns during downloading
 	// and processing
 	wg sync.WaitGroup
@@ -209,9 +211,16 @@ func (pm *ProtocolManager) Start() {
 	// start sync handlers
 	go pm.syncer()
 	go pm.txsyncLoop()
+
+	//set flag
+	pm.isStarted = true
 }
 
 func (pm *ProtocolManager) Stop() {
+	if !pm.isStarted {
+		return
+	}
+
 	log.Info("Stopping Ethereum protocol")
 
 	pm.txSub.Unsubscribe()         // quits txBroadcastLoop


### PR DESCRIPTION
https://github.com/tendermint/ethermint/issues/76

When do `stack.Stop` get follow error:

```--- FAIL: TestBumpingNonces (0.13s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x6667d2]

goroutine 20 [running]:
panic(0xd03b20, 0xc42000c180)
    /usr/local/go/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc420084240)
    /usr/local/go/src/testing/testing.go:579 +0x25d
panic(0xd03b20, 0xc42000c180)
    /usr/local/go/src/runtime/panic.go:458 +0x243
github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/event.(*TypeMuxSubscription).Unsubscribe(0x0)
    /srv/ethermint/src/github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/event/event.go:179 +0x22
github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/eth.(*ProtocolManager).Stop(0xc42006a8f0)
    /srv/ethermint/src/github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/eth/handler.go:217 +0x6a
github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/eth.(*Ethereum).Stop(0xc4200923c0, 0xc4225e7b78, 0xc4225e7b70)
    /srv/ethermint/src/github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/eth/backend.go:397 +0x52
github.com/tendermint/ethermint/ethereum.(*Backend).Stop(0xc4202dda70, 0xc4202d03c0, 0xc4225e7b58)
    /srv/ethermint/src/github.com/tendermint/ethermint/ethereum/backend.go:138 +0x2f
github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/node.(*Node).Stop(0xc4200966c0, 0x0, 0x0)
    /srv/ethermint/src/github.com/tendermint/ethermint/vendor/github.com/ethereum/go-ethereum/node/node.go:502 +0x1fb```

Because we stops components which has not been started.